### PR TITLE
Make word-memory + thermite engines server-replay-ready

### DIFF
--- a/app/puzzles/thermite/ThermiteGrid.tsx
+++ b/app/puzzles/thermite/ThermiteGrid.tsx
@@ -3,7 +3,8 @@
 import { memo } from 'react';
 import Image from 'next/image';
 import crossImg from '@/public/images/thermite/cross.svg';
-import type { Square } from './utils';
+import type { Square } from './pieces';
+import { pieceImages } from './utils';
 
 interface ThermiteSquareProps {
   square: Square;
@@ -24,7 +25,7 @@ export const ThermiteSquare = memo<ThermiteSquareProps>(
       onClick={() => onSquareClick(row, col)}
     >
       <span className="piece">
-        <Image src={square.piece.img} alt="" width={75} height={75} />
+        <Image src={pieceImages[square.piece.type]} alt="" width={75} height={75} />
       </span>
       <div className="crosses">
         <Image src={crossImg} alt="" width={16} height={16} />

--- a/app/puzzles/thermite/engine.ts
+++ b/app/puzzles/thermite/engine.ts
@@ -1,5 +1,5 @@
 import type { GameEngine } from '@/app/game/types';
-import { squarePieces, type GridRow, type Square, type SquareCoord, type SquarePiece } from './utils';
+import { squarePieces, type GridRow, type Square, type SquareCoord, type SquarePiece } from './pieces';
 
 export interface ThermiteState {
   board: GridRow[];

--- a/app/puzzles/thermite/pieces.ts
+++ b/app/puzzles/thermite/pieces.ts
@@ -1,0 +1,22 @@
+// Pure piece data — no asset imports — so the engine module stays server-importable.
+export type PieceType = 'short' | 'medium' | 'long';
+
+export type SquarePiece = { type: PieceType; distance: number };
+
+export const squarePieces: SquarePiece[] = [
+  { type: 'short', distance: 1 },
+  { type: 'medium', distance: 2 },
+  { type: 'long', distance: 3 },
+];
+
+export type SquareStatus = 'full' | 'half' | 'empty';
+
+export type Square = {
+  piece: SquarePiece;
+  status: SquareStatus;
+  highlighted: boolean;
+};
+
+export type GridRow = Array<Square>;
+
+export type SquareCoord = [row: number, col: number];

--- a/app/puzzles/thermite/utils.ts
+++ b/app/puzzles/thermite/utils.ts
@@ -1,113 +1,36 @@
-import shortImg from "@/public/images/thermite/short.svg";
-import mediumImg from "@/public/images/thermite/medium.svg";
-import longImg from "@/public/images/thermite/long.svg";
+import type { StaticImageData } from 'next/image';
+import shortImg from '@/public/images/thermite/short.svg';
+import mediumImg from '@/public/images/thermite/medium.svg';
+import longImg from '@/public/images/thermite/long.svg';
+import type { PieceType } from './pieces';
 
-export type PieceType = "short" | "medium" | "long";
-export type SquarePiece = {type: PieceType, distance: number, img: any};
-export const squarePieces: SquarePiece[] = [
-    {
-        type: "short",
-        distance: 1,
-        img: shortImg,
-    },
-    {
-        type: "medium",
-        distance: 2,
-        img: mediumImg,
-    },
-    {
-        type: "long",
-        distance: 3,
-        img: longImg,
-    },
-];
-
-export type SquareStatus = "full" | "half" | "empty";
-export type Square = {
-    piece: SquarePiece,
-    status: SquareStatus,
-    highlighted: boolean
+// Maps a piece type to its SVG — kept out of pieces.ts so the engine stays asset-free.
+export const pieceImages: Record<PieceType, StaticImageData> = {
+  short: shortImg,
+  medium: mediumImg,
+  long: longImg,
 };
-export type GridRow = Array<Square>;
-export type SquareCoord = [
-    row: number,
-    col: number,
-];
-
 
 export const presets = [
-    {
-        label: "Maze Bank - Sewer",
-        timer: 60,
-        targetScore: 24,
-        rows: 6,
-        columns: 6,
-    },
-    {
-        label: "Maze Bank - Vault",
-        timer: 60,
-        targetScore: 28,
-        rows: 6,
-        columns: 6,
-    },
-    {
-        label: "Art Asylum - Water",
-        timer: 25,
-        targetScore: 30,
-        rows: 6,
-        columns: 6,
-    },
+  {
+    label: 'Maze Bank - Sewer',
+    timer: 60,
+    targetScore: 24,
+    rows: 6,
+    columns: 6,
+  },
+  {
+    label: 'Maze Bank - Vault',
+    timer: 60,
+    targetScore: 28,
+    rows: 6,
+    columns: 6,
+  },
+  {
+    label: 'Art Asylum - Water',
+    timer: 25,
+    targetScore: 30,
+    rows: 6,
+    columns: 6,
+  },
 ];
-export const initialBoard: GridRow[] = new Array(presets[0].rows).fill(
-    new Array(presets[0].columns).fill({
-      piece: squarePieces[0],
-      status: "full",
-      highlighted: false,
-    })
-  )
-
-/**
- * Returns a random square piece.
- * 
- * @returns {SquarePiece}
- */
-export const getRandomPiece = (): SquarePiece => {
-    return squarePieces[Math.floor(Math.random() * squarePieces.length)];
-}
-
-/**
- * Returns a square of a random piece.
- * 
- * @param status
- * @param highlighted 
- * @returns {Square}
- */
-export const getRandomSquare = (status: SquareStatus = "full", highlighted: boolean = true): Square => {
-    return {
-        piece: getRandomPiece(),
-        status,
-        highlighted
-    };
-}
-
-/**
- * Returns the status message.
- * 
- * @param status 
- * @returns {string}
- */
-export const getStatusMessage = (status: number | undefined) => {
-    switch (status) {
-        case 0:
-        case 1:
-            return "";
-        case 2:
-            return "Failed!";
-        case 3:
-            return "Success!";
-        case 4:
-            return "Reset!";
-        default:
-            return `Error: Unknown game status ${status}`;
-    }
-}

--- a/app/puzzles/word-memory/engine.ts
+++ b/app/puzzles/word-memory/engine.ts
@@ -1,5 +1,5 @@
 import type { GameEngine } from '@/app/game/types';
-import { generate } from 'random-words';
+import { WORD_BANK } from './wordBank';
 
 export interface WordMemoryState {
   sequence: string[];
@@ -13,9 +13,19 @@ export interface WordMemoryConfig {
 
 export type WordMemoryInput = { type: 'seen' } | { type: 'new' };
 
+// Fisher–Yates over a copy, driven by the injected rng so the draw is reproducible.
+function shuffle<T>(rng: () => number, array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
 export const wordMemoryEngine: GameEngine<WordMemoryState, WordMemoryConfig, WordMemoryInput> = {
   init({ numWords }, rng) {
-    const pool = generate(Math.floor(numWords / 2)) as string[];
+    const pool = shuffle(rng, WORD_BANK).slice(0, Math.floor(numWords / 2));
     const sequence: string[] = [];
     for (let i = 0; i <= numWords; i++) {
       sequence.push(pool[Math.floor(rng() * pool.length)]);

--- a/app/puzzles/word-memory/wordBank.ts
+++ b/app/puzzles/word-memory/wordBank.ts
@@ -1,0 +1,25 @@
+// A fixed pool of common, distinct words. The Word Memory engine samples from
+// this via its injected rng, so word generation is deterministic and replayable.
+export const WORD_BANK: string[] = [
+  'apple', 'river', 'table', 'cloud', 'stone', 'bridge', 'garden', 'candle',
+  'pencil', 'window', 'forest', 'planet', 'rocket', 'basket', 'copper', 'silver',
+  'marble', 'velvet', 'cotton', 'anchor', 'harbor', 'island', 'valley', 'meadow',
+  'canyon', 'desert', 'glacier', 'thunder', 'rainbow', 'blossom', 'harvest', 'lantern',
+  'compass', 'telescope', 'mountain', 'fountain', 'cottage', 'castle', 'tower', 'cellar',
+  'hallway', 'balcony', 'chimney', 'mirror', 'drawer', 'ladder', 'hammer', 'wrench',
+  'needle', 'thread', 'button', 'ribbon', 'blanket', 'pillow', 'mattress', 'curtain',
+  'carpet', 'ceiling', 'kitchen', 'pantry', 'closet', 'garage', 'driveway', 'sidewalk',
+  'highway', 'tunnel', 'railway', 'station', 'airport', 'lighthouse', 'windmill', 'stadium',
+  'library', 'museum', 'market', 'factory', 'chapel', 'palace', 'fortress', 'cathedral',
+  'rabbit', 'falcon', 'otter', 'badger', 'beaver', 'hedgehog', 'dolphin', 'penguin',
+  'walrus', 'panther', 'leopard', 'jaguar', 'raccoon', 'squirrel', 'sparrow', 'heron',
+  'pelican', 'tortoise', 'lizard', 'salmon', 'lobster', 'jellyfish', 'octopus', 'butterfly',
+  'dragonfly', 'beetle', 'cricket', 'pumpkin', 'walnut', 'almond', 'cherry', 'peach',
+  'melon', 'apricot', 'biscuit', 'pretzel', 'muffin', 'waffle', 'pancake', 'noodle',
+  'pepper', 'ginger', 'cinnamon', 'vanilla', 'caramel', 'custard', 'clover', 'maple',
+  'willow', 'cedar', 'birch', 'cactus', 'orchid', 'tulip', 'daisy', 'poppy',
+  'thistle', 'bamboo', 'festival', 'carnival', 'parade', 'journey', 'voyage', 'treasure',
+  'puzzle', 'riddle', 'melody', 'rhythm', 'shadow', 'ember', 'pebble', 'boulder',
+  'gravel', 'crystal', 'granite', 'bronze', 'leather', 'comet', 'meteor', 'galaxy',
+  'eclipse', 'aurora', 'blizzard', 'breeze', 'sunrise', 'sunset', 'whistle', 'magnet',
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "lucide-react": "^0.548.0",
         "mongodb": "^6.7.0",
         "next": "^14.2.3",
-        "random-words": "^2.0.1",
         "react": "^18",
         "react-dom": "^18",
         "sharp": "^0.33.2"
@@ -5304,15 +5303,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/random-words": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/random-words/-/random-words-2.0.1.tgz",
-      "integrity": "sha512-nZNJAmgcFmtJMTDDIUCm/iK4R6RydC6NvALvWhYItXQrgYGk1F7Gww416LpVROFQtfVd5TaLEf4WuSsko03N7w==",
-      "license": "MIT",
-      "dependencies": {
-        "seedrandom": "^3.0.5"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5583,12 +5573,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lucide-react": "^0.548.0",
     "mongodb": "^6.7.0",
     "next": "^14.2.3",
-    "random-words": "^2.0.1",
     "react": "^18",
     "react-dom": "^18",
     "sharp": "^0.33.2"

--- a/scripts/determinism-spike.ts
+++ b/scripts/determinism-spike.ts
@@ -1,0 +1,123 @@
+/**
+ * Determinism spike — validates the load-bearing 1v1 assumption: a pure engine,
+ * replayed from (seed, inputs), yields a bit-identical end state.
+ *
+ * For each engine: init with a seeded RNG, apply a fixed input sequence, do it
+ * again, and diff. PASS means the engine is replay-ready for server-side
+ * verification; FAIL means it pulls in randomness the injected rng doesn't control.
+ *
+ * Run: npx --yes tsx scripts/determinism-spike.ts
+ */
+import { roofRunningEngine } from '../app/puzzles/roof-running/engine';
+import { pincrackerEngine } from '../app/puzzles/pincracker/engine';
+import { lockpickEngine } from '../app/components/lockpickEngine';
+import { repairKitEngine } from '../app/puzzles/repair-kit/engine';
+import { thermiteEngine } from '../app/puzzles/thermite/engine';
+import { choppingEngine } from '../app/puzzles/chopping/engine';
+import { wordMemoryEngine } from '../app/puzzles/word-memory/engine';
+
+// Deterministic LCG — the same generator the daily-challenge route uses.
+function seededRandom(seed: number): () => number {
+  let value = seed;
+  return () => {
+    value = (value * 9301 + 49297) % 233280;
+    return value / 233280;
+  };
+}
+
+// Replays an engine from a seed + fixed input sequence; returns the final state.
+function replay(engine: any, seed: number, config: any, inputs: any[]) {
+  let state = engine.init(config, seededRandom(seed));
+  for (const input of inputs) {
+    state = engine.applyInput(state, input).state;
+  }
+  return state;
+}
+
+const SEED = 12345;
+
+// Inputs need not be "winning" — any fixed sequence proves (or breaks) determinism.
+const cases: { name: string; engine: any; config: any; inputs: any[] }[] = [
+  {
+    name: 'roof-running',
+    engine: roofRunningEngine,
+    config: { rows: 8, columns: 11 },
+    inputs: [0, 5, 12, 30, 50, 7, 80].map((index) => ({ type: 'click', index })),
+  },
+  {
+    name: 'pincracker',
+    engine: pincrackerEngine,
+    config: { pinLength: 4 },
+    inputs: [
+      { type: 'digit', value: 1 },
+      { type: 'digit', value: 2 },
+      { type: 'digit', value: 3 },
+      { type: 'digit', value: 4 },
+      { type: 'crack' },
+      { type: 'finish', autoClear: true },
+    ],
+  },
+  {
+    name: 'lockpick',
+    engine: lockpickEngine,
+    config: { levels: 4 },
+    inputs: [
+      { type: 'rotate', direction: 1 },
+      { type: 'rotate', direction: 1 },
+      { type: 'unlock' },
+      { type: 'rotate', direction: -1 },
+      { type: 'unlock' },
+    ],
+  },
+  {
+    name: 'repair-kit',
+    engine: repairKitEngine,
+    config: {},
+    inputs: [{ type: 'stop', deviation: 3 }],
+  },
+  {
+    name: 'thermite',
+    engine: thermiteEngine,
+    config: { rows: 6, columns: 6, targetScore: 24 },
+    inputs: [
+      { type: 'click', coord: [0, 0], timestamp: 1000 },
+      { type: 'click', coord: [0, 0], timestamp: 1200 },
+      { type: 'click', coord: [1, 1], timestamp: 1500 },
+      { type: 'click', coord: [2, 2], timestamp: 1800 },
+    ],
+  },
+  {
+    name: 'chopping',
+    engine: choppingEngine,
+    config: { numLetters: 15 },
+    inputs: ['Q', 'W', 'E', 'R', 'A', 'S', 'D'],
+  },
+  {
+    name: 'word-memory',
+    engine: wordMemoryEngine,
+    config: { numWords: 25 },
+    inputs: [{ type: 'seen' }, { type: 'new' }, { type: 'new' }, { type: 'seen' }],
+  },
+];
+
+console.log('Determinism spike — replaying each engine twice from the same (seed, inputs)\n');
+let pass = 0;
+let fail = 0;
+let errored = 0;
+for (const c of cases) {
+  try {
+    const a = JSON.stringify(replay(c.engine, SEED, c.config, c.inputs));
+    const b = JSON.stringify(replay(c.engine, SEED, c.config, c.inputs));
+    if (a === b) {
+      console.log(`  PASS   ${c.name.padEnd(13)} bit-identical (${a.length} chars)`);
+      pass++;
+    } else {
+      console.log(`  FAIL   ${c.name.padEnd(13)} replays DIVERGED — non-deterministic`);
+      fail++;
+    }
+  } catch (err) {
+    console.log(`  ERROR  ${c.name.padEnd(13)} ${(err as Error).message}`);
+    errored++;
+  }
+}
+console.log(`\n${pass} deterministic / ${fail} non-deterministic / ${errored} errored`);


### PR DESCRIPTION
## Summary

1v1 prep. A determinism spike found two engines weren't ready for server-side replay verification — both are now fixed, and all 7 1v1-eligible engines replay bit-identically from the same `(seed, inputs)`.

- **word-memory** — was non-deterministic: it drew its word pool from the `random-words` library, which uses `Math.random()` internally, bypassing the injected `rng` (so the same seed produced different words — also a latent daily-challenge fairness issue). Replaced with a bundled `WORD_BANK` sampled via the `rng`; dropped the `random-words` dependency.
- **thermite** — its engine module couldn't be imported outside the Next.js build: `utils.ts` co-located the `squarePieces` data the engine needs with SVG asset imports. Split the pure piece data + types into `pieces.ts` (no asset imports); `utils.ts` keeps the SVGs as a `pieceImages` map keyed by piece type. Dropped dead helpers (`getRandomPiece`, `getRandomSquare`, `initialBoard`, `getStatusMessage`).
- **`scripts/determinism-spike.ts`** — added as a regression check: replays each engine twice from the same `(seed, inputs)` and diffs the end state.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, and `npx tsx scripts/determinism-spike.ts` pass (spike shows 7/7)
- [x] Play word-memory — game plays the same; words now come from the bundled bank
- [x] Play thermite — short/medium/long piece SVGs still render, game plays normally