### PR TITLE
fix(mobile): stop swallowing keystrokes aimed at the games' hidden input

### DIFF
--- a/app/puzzles/chopping/Chopping.tsx
+++ b/app/puzzles/chopping/Chopping.tsx
@@ -7,6 +7,7 @@ import usePersistantState from '@/app/utils/usePersistentState';
 import { useKeyDown } from '@/app/utils/useKeyDown';
 import { useDailyChallenge } from '@/app/utils/useDailyChallenge';
 import { useMobileGameViewport } from '@/app/utils/useMobileGameViewport';
+import { useSoftKeyboardInput } from '@/app/utils/useSoftKeyboardInput';
 import { trackGameStart, trackGameRetry } from '@/app/utils/gtm';
 import { useUser } from '@/app/contexts/UserContext';
 import { NPSettingsRange } from '@/app/components/NPSettings';
@@ -17,6 +18,7 @@ import type { GameMode, GamePhase, GameResult } from '@/app/game/types';
 import { useReplayedState } from '@/app/utils/useReplayedState';
 import OpponentSummary from '@/app/lobby/OpponentSummary';
 import { choppingEngine, type ChoppingState } from './engine';
+import { Letters } from './utils';
 import { GridRow, defaultGridCols } from './ChoppingGrid';
 import '../../../public/Chopping/Chopping.css';
 
@@ -38,7 +40,8 @@ interface ChoppingViewProps {
   // activation. Spectator views omit these.
   wrapperRef?: React.Ref<HTMLDivElement>;
   onInteraction?: () => void;
-  // Interactive-only: hidden mobile input rendered inside the GameShell.
+  // Interactive-only: hidden mobile input, overlaid on the grid so tapping the
+  // puzzle focuses it directly and Android reliably raises the keyboard.
   mobileInput?: ReactNode;
   settings?: React.ComponentProps<typeof GameShell>['settings'];
 }
@@ -69,14 +72,14 @@ const ChoppingView: FC<ChoppingViewProps> = ({
     hideTimer={hideTimer}
     settings={settings}
   >
-    {mobileInput}
     <div
       ref={wrapperRef}
-      className={`${compact ? '' : 'min-w-[calc(100vw-60px)] sm:min-w-[550px] md:min-w-[600px] '}w-full max-w-full flex-1 min-h-0 rounded-lg bg-[rgba(0,28,49,0.3)] flex items-center justify-center text-white p-1 sm:p-4 mx-auto`}
+      className={`relative ${compact ? '' : 'min-w-[calc(100vw-60px)] sm:min-w-[550px] md:min-w-[600px] '}w-full max-w-full flex-1 min-h-0 rounded-lg bg-[rgba(0,28,49,0.3)] flex items-center justify-center text-white p-1 sm:p-4 mx-auto`}
       onTouchStartCapture={onInteraction}
       onPointerDownCapture={onInteraction}
       style={{ scrollMarginTop: '15vh', overflow: 'visible' }}
     >
+      {mobileInput}
       <div className="game-grid" style={{ height: '100%', width: '100%' }}>
         {Array.from({ length: Math.ceil(state.board.length / defaultGridCols) }).map(
           (_, rowIndex) => (
@@ -173,7 +176,6 @@ const Chopping: FC<ChoppingProps> = ({ seed, onMatchEnd, onInput }) => {
   const outerContainerRef = useRef<HTMLDivElement>(null);
   const gameWrapperRef = useRef<HTMLDivElement>(null);
   const mobileInputRef = useRef<HTMLInputElement>(null);
-  const skipNextInputRef = useRef(false);
   const prevActiveIndexRef = useRef(0);
 
   const mobile = useMobileGameViewport({
@@ -233,39 +235,28 @@ const Chopping: FC<ChoppingProps> = ({ seed, onMatchEnd, onInput }) => {
   );
   useKeyDown(handleKey, ALLOWED_KEYS, true);
 
-  const handleMobileKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (phase !== 'playing') return;
-    const { key } = e;
-    if (key.length === 1) {
-      skipNextInputRef.current = true;
-      e.preventDefault();
-      mobile.dismissHint();
-      submitInput(key.toUpperCase());
-      if (mobileInputRef.current) mobileInputRef.current.value = '';
-      return;
-    }
-    if (key === 'Backspace') {
-      skipNextInputRef.current = true;
-      e.preventDefault();
-      if (mobileInputRef.current) mobileInputRef.current.value = '';
-    }
-  };
+  const phaseRef = useRef(phase);
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
 
-  const handleMobileInput = (e: React.FormEvent<HTMLInputElement>) => {
-    const input = e.currentTarget;
-    if (skipNextInputRef.current) {
-      skipNextInputRef.current = false;
-      input.value = '';
-      return;
-    }
-    const key = input.value.slice(-1);
-    if (key && phase === 'playing') {
-      mobile.dismissHint();
-      submitInput(key.toUpperCase());
-      input.value = '';
-      mobile.focusInput();
-    }
-  };
+  const handleSoftKey = useCallback(
+    (key: string) => {
+      if (phaseRef.current === 'playing' && key.length === 1) submitInput(key);
+    },
+    [submitInput],
+  );
+  const acceptLetter = useCallback((char: string) => {
+    const upper = char.toUpperCase();
+    return (Letters as string[]).includes(upper) ? upper : null;
+  }, []);
+
+  const keyboard = useSoftKeyboardInput({
+    enabled: mobile.isMobile,
+    inputRef: mobileInputRef,
+    onKey: handleSoftKey,
+    accept: acceptLetter,
+  });
 
   const [settingsNumLetters, setSettingsNumLetters] = useState(defaultNumLetters);
   const [settingsDuration, setSettingsDuration] = useState(defaultDuration);
@@ -332,10 +323,14 @@ const Chopping: FC<ChoppingProps> = ({ seed, onMatchEnd, onInput }) => {
         />
       )}
       <div ref={outerContainerRef} className="flex flex-col gap-4">
-        {mobile.isMobile && mobile.showHint && (
-          <div className="rounded-xl border border-spring-green-500/40 bg-mirage-900/70 px-4 py-3 text-center text-xs font-medium text-spring-green-100 shadow-lg shadow-mirage-950/40">
-            Tap the puzzle, then type the letters to play.
-          </div>
+        {mobile.isMobile && phase === 'playing' && !keyboard.isFocused && (
+          <button
+            type="button"
+            onClick={keyboard.focus}
+            className="rounded-xl border border-spring-green-500/40 bg-mirage-900/70 px-4 py-3 text-center text-xs font-medium text-spring-green-100 shadow-lg shadow-mirage-950/40"
+          >
+            Tap the puzzle to open your keyboard, then type the letters.
+          </button>
         )}
         <ChoppingView
           state={state}
@@ -348,33 +343,17 @@ const Chopping: FC<ChoppingProps> = ({ seed, onMatchEnd, onInput }) => {
           wrapperRef={gameWrapperRef}
           onInteraction={mobile.handleInteraction}
           settings={isMatch || isChallengeMode ? undefined : settings}
+          // Stays mounted across rounds: unmounting it drops focus, and Android
+          // will not reopen the keyboard without a fresh tap.
           mobileInput={
-            mobile.isMobile && phase === 'playing' ? (
+            mobile.isMobile ? (
               <input
+                {...keyboard.inputProps}
                 ref={mobileInputRef}
-                type="text"
                 inputMode="text"
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="characters"
-                className="opacity-0"
-                style={{
-                  position: 'fixed',
-                  top: 0,
-                  left: 0,
-                  width: '1px',
-                  height: '1px',
-                  background: 'transparent',
-                }}
-                onInput={handleMobileInput}
-                onKeyDown={handleMobileKeyDown}
-                onFocus={() => mobile.focusInput()}
-                onBlur={(e) => {
-                  if (phase === 'playing') {
-                    e.preventDefault();
-                    e.target.focus({ preventScroll: true });
-                  }
-                }}
+                className="absolute inset-0 z-10 h-full w-full bg-transparent opacity-0"
+                // 16px keeps iOS from zooming the page when the field takes focus.
+                style={{ fontSize: '16px' }}
                 aria-label="Type letters here"
               />
             ) : null

--- a/app/puzzles/pincracker/Pincracker.tsx
+++ b/app/puzzles/pincracker/Pincracker.tsx
@@ -7,6 +7,7 @@ import usePersistantState from '@/app/utils/usePersistentState';
 import { useKeyDown } from '@/app/utils/useKeyDown';
 import { useDailyChallenge } from '@/app/utils/useDailyChallenge';
 import { useMobileGameViewport } from '@/app/utils/useMobileGameViewport';
+import { useSoftKeyboardInput } from '@/app/utils/useSoftKeyboardInput';
 import { trackGameStart, trackGameRetry } from '@/app/utils/gtm';
 import { useUser } from '@/app/contexts/UserContext';
 import { NPSettingsRange } from '@/app/components/NPSettings';
@@ -37,7 +38,8 @@ interface PincrackerViewProps {
   // Interactive-only. When omitted, no Crack button is rendered and the grid
   // is non-interactive.
   onCrack?: () => void;
-  // Interactive-only: optional hidden mobile input rendered inside the GameShell.
+  // Interactive-only: hidden mobile input, overlaid on the grid so tapping the
+  // puzzle focuses it directly and Android reliably raises the keyboard.
   mobileInput?: ReactNode;
   wrapperRef?: React.Ref<HTMLDivElement>;
   onInteraction?: () => void;
@@ -126,10 +128,9 @@ const PincrackerView: FC<PincrackerViewProps> = ({
       hideTimer={hideTimer}
       settings={settings}
     >
-      {mobileInput}
       <div
         ref={wrapperRef}
-        className={`h-56 sm:h-60 md:h-64 ${
+        className={`relative h-56 sm:h-60 md:h-64 ${
           compact ? '' : 'min-w-[calc(100vw-60px)] sm:min-w-[550px] md:min-w-[600px] '
         }w-full max-w-full rounded-lg bg-[rgba(0,28,49,0.3)] flex items-center justify-between text-white text-6xl sm:text-7xl md:text-8xl px-3 sm:px-5 md:px-6 mx-auto ${
           !onCrack ? 'pointer-events-none' : ''
@@ -138,6 +139,7 @@ const PincrackerView: FC<PincrackerViewProps> = ({
         onPointerDownCapture={onInteraction}
         style={{ scrollMarginTop: '15vh' }}
       >
+        {mobileInput}
         {state.guess.map((digit, index) => (
           <PinColumn
             key={index}
@@ -290,9 +292,8 @@ const Pincracker: FC<PincrackerProps> = ({ seed, onMatchEnd, onInput }) => {
       } else {
         submitInput({ type: 'digit', value: key as Digit });
       }
-      mobile.focusInput();
     },
-    [submitInput, mobile.focusInput],
+    [submitInput],
   );
 
   const handleKey = useCallback(
@@ -303,28 +304,28 @@ const Pincracker: FC<PincrackerProps> = ({ seed, onMatchEnd, onInput }) => {
   );
   useKeyDown(handleKey, ALLOWED_KEYS, true);
 
-  const handleMobileInput = (e: React.FormEvent<HTMLInputElement>) => {
-    const input = e.currentTarget;
-    const key = input.value.slice(-1);
-    if (!key || phase !== 'playing') {
-      if (!key) input.value = '';
-      return;
-    }
-    mobile.dismissHint();
-    submitKey(key);
-    input.value = '';
-  };
+  const phaseRef = useRef(phase);
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
 
-  const handleMobileKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (phase !== 'playing') return;
-    if (e.key === 'Backspace') {
-      mobile.dismissHint();
-      submitKey('Backspace');
-    } else if (e.key === 'Enter') {
-      mobile.dismissHint();
-      submitKey('Enter');
-    }
-  };
+  const handleSoftKey = useCallback(
+    (key: string) => {
+      if (phaseRef.current === 'playing') submitKey(key);
+    },
+    [submitKey],
+  );
+  const acceptDigit = useCallback(
+    (char: string) => (char >= '0' && char <= '9' ? char : null),
+    [],
+  );
+
+  const keyboard = useSoftKeyboardInput({
+    enabled: mobile.isMobile,
+    inputRef: mobileInputRef,
+    onKey: handleSoftKey,
+    accept: acceptDigit,
+  });
 
   const [settingsPinLength, setSettingsPinLength] = useState(defaultPinLength);
   const [settingsDuration, setSettingsDuration] = useState(defaultDuration);
@@ -403,10 +404,14 @@ const Pincracker: FC<PincrackerProps> = ({ seed, onMatchEnd, onInput }) => {
         />
       )}
       <div ref={outerContainerRef} className="flex flex-col gap-4">
-        {mobile.isMobile && mobile.showHint && (
-          <div className="rounded-xl border border-spring-green-500/40 bg-mirage-900/70 px-4 py-3 text-center text-xs font-medium text-spring-green-100 shadow-lg shadow-mirage-950/40">
-            Tap the puzzle, then start typing to enter the code.
-          </div>
+        {mobile.isMobile && phase === 'playing' && !keyboard.isFocused && (
+          <button
+            type="button"
+            onClick={keyboard.focus}
+            className="rounded-xl border border-spring-green-500/40 bg-mirage-900/70 px-4 py-3 text-center text-xs font-medium text-spring-green-100 shadow-lg shadow-mirage-950/40"
+          >
+            Tap the puzzle to open your keyboard, then type the code.
+          </button>
         )}
         <PincrackerView
           state={state}
@@ -422,32 +427,18 @@ const Pincracker: FC<PincrackerProps> = ({ seed, onMatchEnd, onInput }) => {
           wrapperRef={gameWrapperRef}
           onInteraction={mobile.handleInteraction}
           settings={isMatch || isChallengeMode ? undefined : settings}
+          // Stays mounted across rounds: unmounting it drops focus, and Android
+          // will not reopen the keyboard without a fresh tap.
           mobileInput={
-            mobile.isMobile && phase === 'playing' ? (
+            mobile.isMobile ? (
               <input
+                {...keyboard.inputProps}
                 ref={mobileInputRef}
-                type="tel"
                 inputMode="numeric"
-                pattern="[0-9]*"
-                autoComplete="off"
-                className="opacity-0"
-                style={{
-                  position: 'fixed',
-                  top: 0,
-                  left: 0,
-                  width: '1px',
-                  height: '1px',
-                  background: 'transparent',
-                }}
-                onInput={handleMobileInput}
-                onKeyDown={handleMobileKeyDown}
-                onFocus={() => mobile.focusInput()}
-                onBlur={(e) => {
-                  if (phase === 'playing') {
-                    e.preventDefault();
-                    e.target.focus({ preventScroll: true });
-                  }
-                }}
+                enterKeyHint="go"
+                className="absolute inset-0 z-10 h-full w-full bg-transparent opacity-0"
+                // 16px keeps iOS from zooming the page when the field takes focus.
+                style={{ fontSize: '16px' }}
                 aria-label="Enter PIN digits"
               />
             ) : null

--- a/app/utils/useKeyDown.ts
+++ b/app/utils/useKeyDown.ts
@@ -3,6 +3,19 @@ import { useCallback, useEffect } from 'react';
 export const useKeyDown = (callback: (key?: string) => any, keys: string[], enabled: boolean) => {
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      // Never swallow keys aimed at a text field. The mobile games focus a hidden
+      // input and read the keystrokes back off its value, so calling
+      // preventDefault() here stopped the character from ever being inserted —
+      // on any keyboard that reports a real event.key rather than Android's
+      // composing-IME placeholder.
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+      ) {
+        return;
+      }
+
       const anyKeyPressed = keys.some((key) => event.key === key);
 
       if (anyKeyPressed) {

--- a/app/utils/useMobileGameViewport.ts
+++ b/app/utils/useMobileGameViewport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { useIsMobileOrTablet } from '@/app/utils/useMediaQuery';
 
 interface UseMobileGameViewportArgs {
@@ -10,15 +10,14 @@ interface UseMobileGameViewportArgs {
 
 export interface MobileGameViewport {
   isMobile: boolean;
-  showHint: boolean;
   ensureVisible: (behavior?: ScrollBehavior) => void;
   focusInput: (options?: { force?: boolean }) => void;
   handleInteraction: () => void;
-  dismissHint: () => void;
 }
 
-// Shared mobile keyboard handling: keeps the puzzle centered above the on-screen keyboard,
-// manages the hidden input's focus, and the one-time "tap to play" hint.
+// Shared mobile keyboard handling: keeps the puzzle centered above the on-screen
+// keyboard and manages the hidden input's focus. Reading the keystrokes out of
+// that input is useSoftKeyboardInput's job.
 export function useMobileGameViewport({
   isPlaying,
   outerRef,
@@ -26,8 +25,6 @@ export function useMobileGameViewport({
   inputRef,
 }: UseMobileGameViewportArgs): MobileGameViewport {
   const isMobile = useIsMobileOrTablet();
-  const [showHint, setShowHint] = useState(false);
-  const hintDismissedRef = useRef(false);
   const hasInteractedRef = useRef(false);
 
   const ensureVisible = useCallback(
@@ -50,12 +47,6 @@ export function useMobileGameViewport({
     setTimeout(() => ensureVisible('smooth'), 500);
   }, [ensureVisible]);
 
-  const dismissHint = useCallback(() => {
-    if (hintDismissedRef.current) return;
-    hintDismissedRef.current = true;
-    setShowHint(false);
-  }, []);
-
   const focusInput = useCallback(
     (options?: { force?: boolean }) => {
       if (!isMobile) return;
@@ -67,20 +58,16 @@ export function useMobileGameViewport({
       } catch {
         input.focus();
       }
-      input.setSelectionRange?.(input.value.length, input.value.length);
-      // Deliberately NO re-centering here: games re-focus on every keystroke,
-      // and scrolling per keypress made the page fight the player. Centering
-      // happens once on interaction/round-start/keyboard-open instead.
+      // Deliberately NO re-centering here: scrolling per focus made the page
+      // fight the player. Centering happens once on interaction/round-start/
+      // keyboard-open instead.
     },
     [isMobile, inputRef],
   );
 
   const handleInteraction = useCallback(() => {
     if (!isMobile) return;
-    if (!hasInteractedRef.current) {
-      hasInteractedRef.current = true;
-      dismissHint();
-    }
+    hasInteractedRef.current = true;
     const input = inputRef.current;
     if (!input) return;
     try {
@@ -96,7 +83,7 @@ export function useMobileGameViewport({
       }
     });
     scrollSoon();
-  }, [isMobile, inputRef, dismissHint, scrollSoon]);
+  }, [isMobile, inputRef, scrollSoon]);
 
   // Center the puzzle shortly after it mounts on mobile.
   useEffect(() => {
@@ -141,10 +128,5 @@ export function useMobileGameViewport({
     };
   }, [isMobile, ensureVisible]);
 
-  // Show the one-time hint while playing on mobile, until the player first interacts.
-  useEffect(() => {
-    setShowHint(isMobile && isPlaying && !hintDismissedRef.current);
-  }, [isMobile, isPlaying]);
-
-  return { isMobile, showHint, ensureVisible, focusInput, handleInteraction, dismissHint };
+  return { isMobile, ensureVisible, focusInput, handleInteraction };
 }

--- a/app/utils/useSoftKeyboardInput.ts
+++ b/app/utils/useSoftKeyboardInput.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+// The hidden field is kept padded with filler and read as a positional diff
+// rather than being cleared after every keystroke. Two Android behaviours make
+// the naive "read value, reset to ''" approach drop input on some keyboards:
+// an empty field has nothing to delete, so Backspace emits no event at all,
+// and rewriting value mid-composition invalidates the IME's composing region,
+// after which it stops emitting until the field is re-focused.
+const FILLER = 'x';
+const BUFFER_LENGTH = 24;
+const MIN_LENGTH = 8;
+const MAX_LENGTH = 64;
+// A real Backspace deletes one character per event; anything larger is an IME
+// rewriting the buffer, and replaying it as deletes would eat the player's guess.
+const MAX_DELETES_PER_EVENT = 4;
+
+interface InputDiff {
+  removed: number;
+  inserted: string;
+}
+
+// Longest common prefix/suffix diff — the only reliable way to read an IME that
+// may replace a span rather than append a character. Exported for testing.
+export function diffValue(prev: string, next: string): InputDiff {
+  const max = Math.min(prev.length, next.length);
+  let start = 0;
+  while (start < max && prev[start] === next[start]) start += 1;
+  let end = 0;
+  while (end < max - start && prev[prev.length - 1 - end] === next[next.length - 1 - end]) end += 1;
+  return { removed: prev.length - start - end, inserted: next.slice(start, next.length - end) };
+}
+
+interface UseSoftKeyboardInputArgs {
+  // Mount/arm the field — typically `isMobile && phase === 'playing'`.
+  enabled: boolean;
+  inputRef: RefObject<HTMLInputElement>;
+  // Receives 'Backspace', 'Enter', or a single accepted character.
+  onKey: (key: string) => void;
+  // Filter for inserted characters, applied before onKey. Return the character
+  // to submit (allows normalising case) or null to drop it.
+  accept: (char: string) => string | null;
+}
+
+export interface SoftKeyboardInput {
+  // Spread onto the hidden input. The caller still owns `ref` and styling.
+  inputProps: React.InputHTMLAttributes<HTMLInputElement>;
+  // False while the keyboard is dismissed, so the game can prompt to tap.
+  isFocused: boolean;
+  focus: () => void;
+}
+
+// Bridges an on-screen keyboard to a game that consumes single keys, via a
+// hidden input that stays padded so every IME has something to act on.
+export function useSoftKeyboardInput({
+  enabled,
+  inputRef,
+  onKey,
+  accept,
+}: UseSoftKeyboardInputArgs): SoftKeyboardInput {
+  const [isFocused, setIsFocused] = useState(false);
+  const lastValueRef = useRef('');
+  const composingRef = useRef(false);
+  const onKeyRef = useRef(onKey);
+  const acceptRef = useRef(accept);
+
+  useEffect(() => {
+    onKeyRef.current = onKey;
+    acceptRef.current = accept;
+  }, [onKey, accept]);
+
+  const refill = useCallback(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    const value = FILLER.repeat(BUFFER_LENGTH);
+    input.value = value;
+    lastValueRef.current = value;
+    try {
+      input.setSelectionRange(value.length, value.length);
+    } catch {
+      // Selection is unsupported on some input types; the diff copes without it.
+    }
+  }, [inputRef]);
+
+  const focus = useCallback(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    try {
+      input.focus({ preventScroll: true });
+    } catch {
+      input.focus();
+    }
+  }, [inputRef]);
+
+  // Arm the buffer as soon as the field mounts so the first keystroke — which
+  // may be a Backspace — already has filler to consume.
+  useEffect(() => {
+    if (enabled) refill();
+  }, [enabled, refill]);
+
+  const read = useCallback(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    const next = input.value;
+    const { removed, inserted } = diffValue(lastValueRef.current, next);
+    lastValueRef.current = next;
+
+    if (inserted) {
+      for (const char of inserted) {
+        // Numeric keypads expose Enter as a Go/Done key that inserts a newline
+        // instead of raising a keydown on some Android keyboards.
+        if (char === '\n' || char === '\r') {
+          onKeyRef.current('Enter');
+          continue;
+        }
+        const key = acceptRef.current(char);
+        if (key) onKeyRef.current(key);
+      }
+    } else if (removed > 0) {
+      const deletes = Math.min(removed, MAX_DELETES_PER_EVENT);
+      for (let i = 0; i < deletes; i += 1) onKeyRef.current('Backspace');
+    }
+
+    // Never resize the field mid-composition; that is what desyncs the IME.
+    if (composingRef.current) return;
+    if (next.length < MIN_LENGTH || next.length > MAX_LENGTH) refill();
+  }, [inputRef, refill]);
+
+  const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+    // type="text" + inputMode is better supported across Android keyboards than
+    // type="tel", which opens a dialpad IME with its own quirks.
+    type: 'text',
+    autoComplete: 'off',
+    autoCorrect: 'off',
+    autoCapitalize: 'off',
+    spellCheck: false,
+    onInput: read,
+    onCompositionStart: () => {
+      composingRef.current = true;
+    },
+    onCompositionEnd: () => {
+      composingRef.current = false;
+      read();
+    },
+    onKeyDown: (e) => {
+      // Enter is the one key that leaves the value untouched on a hardware
+      // keyboard, so the diff cannot see it. Everything else routes through read().
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onKeyRef.current('Enter');
+      }
+    },
+    onFocus: () => {
+      setIsFocused(true);
+      refill();
+    },
+    onBlur: () => setIsFocused(false),
+  };
+
+  return { inputProps, isFocused, focus };
+}


### PR DESCRIPTION
Ref #73 — mobile keypad input not registering on some Android devices.

## Root cause

`useKeyDown` called `event.preventDefault()` from a **document-level** listener *before* the per-game "is an input focused?" guard ran:

```js
if (anyKeyPressed) {
  event.preventDefault();   // fires even when the hidden input is focused
  callback(event.key);      // ...and only THEN does handleKey check activeElement
}
```

PinCracker and Chopping focus a hidden input on mobile and read keystrokes back off its value. `preventDefault()` stopped the character from ever being inserted, so no `input` event fired — and the game's own `activeElement?.tagName !== 'INPUT'` guard then blocked the document-level fallback. Both paths dead.

**Why only some Android devices:** most Android soft keyboards report `event.key === 'Unidentified'` (keyCode 229) for composing input, which never matched `ALLOWED_KEYS` and so was never swallowed. Keyboards that report real key values matched, and got swallowed.

## Changes

- **`useKeyDown.ts`** — bail out when the event targets an `INPUT`/`TEXTAREA`/contenteditable. Non-input targets are untouched, so desktop behaviour is unchanged.
- **`useSoftKeyboardInput.ts`** (new) — replaces the read-then-clear hidden input. Keeps the field padded with filler and reads changes as a prefix/suffix diff. Fixes a second bug: **mobile Backspace never worked**, because an empty field has nothing to delete and emits no event on any keyboard. Also stops rewriting the value mid-composition and drops the `onBlur` force-refocus that made the keyboard impossible to dismiss.
- **`Pincracker.tsx` / `Chopping.tsx`** — wired to the hook. The input now overlays the board, so a tap focuses it natively instead of via a synthetic `focus()`, and it stays mounted between rounds (Android will not reopen the keyboard without a fresh tap).
- **`useMobileGameViewport.ts`** — dropped the now-unused hint state and per-keystroke caret handling.

## Verification

Reproduced the bug on the original code in mobile-emulated Chromium (Pixel 5): input focused, pressed `1` and `2`, input value stayed `""`, board stayed empty. Confirmed fixed after.

Mobile, all passing: digits land · Backspace registers · full guess + Enter triggers the reveal · sustained typing survives buffer refills · Chopping letters land with case normalisation · focus survives a round transition.

Desktop (1440×900): no hidden input rendered, typing and Backspace work, Space still swallowed on lockpick rather than scrolling the page.

Plus 10 unit cases against the diff algorithm. Typecheck, lint and build clean.

**Not verified:** a real Android device with a real IME — Playwright cannot emulate composition or keyCode 229. The path that was already working for most users is unexercised by these tests, though the character still inserts and the diff reads it the same way the old `slice(-1)` did.